### PR TITLE
Fix compile error for missing function `strcmp` on gcc5

### DIFF
--- a/tools/smtlib2Xparser-sl/exec/execution_settings.h
+++ b/tools/smtlib2Xparser-sl/exec/execution_settings.h
@@ -17,6 +17,7 @@
 #include "sep/sep_abstract.h"
 
 #include <memory>
+#include <cstring>
 
 namespace slcompparser {
     class ExecutionSettings;


### PR DESCRIPTION
Hi,

I'm from the NUS team, and we had some issues compiling `smtlib2Xparser-sl` on gcc5 (as that's the compiler on our machines). To that end, we've made a minor change to allow compilation on gcc5.

Regards,
Benedict Lee